### PR TITLE
docs: fix typos

### DIFF
--- a/lib/req_telemetry.ex
+++ b/lib/req_telemetry.ex
@@ -146,7 +146,7 @@ defmodule ReqTelemetry do
         Supervisor.start_link(...)
       end
 
-  All events are logged by default, but this can be overriden by passing in a keyword describing
+  All events are logged by default, but this can be overridden by passing in a keyword describing
   the kind of events to log or a list of specific events to log.
 
       # Logs all events

--- a/test/req_telemetry_test.exs
+++ b/test/req_telemetry_test.exs
@@ -111,7 +111,7 @@ defmodule ReqTelemetryTest do
       refute_received {:telemetry, [:req, :request, :pipeline, _], _, _}
     end
 
-    test "can be overriden with options passed to the request", %{mock_req: req} do
+    test "can be overridden with options passed to the request", %{mock_req: req} do
       req.(%{}) |> ReqTelemetry.attach() |> Req.get!(telemetry: false)
       refute_received {:telemetry, [:req, :request, _, _], _, _}
 
@@ -120,7 +120,7 @@ defmodule ReqTelemetryTest do
       refute_received {:telemetry, [:req, :request, :adapter, _], _, _}
     end
 
-    test "excluded in attach/1 can be overriden", %{mock_req: req} do
+    test "excluded in attach/1 can be overridden", %{mock_req: req} do
       req.(%{}) |> ReqTelemetry.attach(false) |> Req.get!(telemetry: [adapter: true])
       assert_received {:telemetry, [:req, :request, :adapter, _], _, _}
       refute_received {:telemetry, [:req, :request, :pipeline, _], _, _}


### PR DESCRIPTION
Found via `typos --hidden --format brief`